### PR TITLE
Override the default `IntoIter::size_hint` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,16 @@ impl<'b, T: Copy> Iterator for IntoIter<'b, T> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.inner {
+            InnerIntoIter::Inline { inline_offset, len, .. } => {
+                let remaining_len = len - inline_offset;
+                (remaining_len, Some(remaining_len))
+            }
+            InnerIntoIter::Chunks { remaining_len, .. } => (remaining_len, Some(remaining_len)),
+        }
+    }
 }
 
 // That's unsized, the fat-pointer pointing


### PR DESCRIPTION
This PR overrides the `Iterator::size_hint` method on the `IntoIter` struct, this helps in guessing how many elements an iterator will be able to return.