### PR TITLE
Introduce the `Uell::from_iter_in` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,15 @@ impl<'b, T: Copy + Default> Uell<'b, T> {
         }
     }
 
+    pub fn from_iter_in<I>(iter: I, bump: &'b Bump) -> Uell<T>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut uell = Uell::new_in(bump);
+        iter.into_iter().for_each(|elem| uell.push(elem));
+        uell
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }


### PR DESCRIPTION
Introduce a helpful method to construct an `Uell` from an `Iterator`without having to write the loop on your side.